### PR TITLE
Fix cron fail on data request (moodle 3.8+)

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -27,7 +27,7 @@ defined ( 'MOODLE_INTERNAL' ) || die ();
 
 class provider implements \core_privacy\local\metadata\null_provider {
 
-    public static function get_reason() {
+    public static function get_reason() : string {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
The signature is changed, now (at least moodle 3.8) it crash the cron.

maybe need different release for this.